### PR TITLE
refactor: Web版動画キャッシュ・プレイヤーのプラットフォーム分岐を改善

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1566,14 +1566,14 @@ SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  audio_service: aa99a6ba2ae7565996015322b0bb024e1d25c6fd
-  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
+  audio_service: cab6c1a0eaf01b5a35b567e11fa67d3cc1956910
+  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 45532e0c1fd1f6a5720af8aa0312470c366b73d2
+  cloud_firestore: 2b3de8a37fcb4eb60f0be0af6b2c18d03410053a
   Firebase: a451a7b61536298fd5cbfe3a746fd40443a50679
-  firebase_analytics: 4f9cca09e65f6c2944a862c6dc86f6bed9fb769c
-  firebase_auth: f547a06ed4933a1da2b9ac8d8c64ae09d113c8e1
-  firebase_core: ba00a168e719694f38960502ceb560285603d073
+  firebase_analytics: 1c038d9e4edf25828a8985c0be4efcb84cdae32a
+  firebase_auth: c90f1b17fe53a1e9a63222d0b2f33256879b1a92
+  firebase_core: 7ca5e04fc97329a2245376eba53c5bed113ca21e
   FirebaseAnalytics: d0a97a0db6425e5a5d966340b87f92ca7b13a557
   FirebaseAppCheckInterop: e2178171b4145013c7c1a3cc464d1d446d3a1896
   FirebaseAuth: 613c463cb43545a7fd2cd99ade09b78ac472c544
@@ -1586,7 +1586,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 631b38da2e11a83daa4bfb482f79d286a5dfa7ad
   FirebaseSharedSwift: 79f27fff0addd15c3de19b87fba426f3cc2c964f
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  google_sign_in_ios: 00dfa94252eb10278b64828c81bcb7158a81a53a
+  google_sign_in_ios: 055d43c4754f2860a53decd5133b78d05615fffd
   GoogleAdsOnDeviceConversion: d68c69dd9581a0f5da02617b6f377e5be483970f
   GoogleAppMeasurement: 3bf40aff49a601af5da1c3345702fcb4991d35ee
   GoogleSignIn: c7f09cfbc85a1abf69187be091997c317cc33b77
@@ -1595,16 +1595,16 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
+  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
-  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  video_player_avfoundation: 7993f492ae0bd77edaea24d9dc051d8bb2cd7c86
+  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
 
 PODFILE CHECKSUM: 1857a7cdb7dfafe45f2b0e9a9af44644190f7506
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1566,14 +1566,14 @@ SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  audio_service: cab6c1a0eaf01b5a35b567e11fa67d3cc1956910
-  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
+  audio_service: aa99a6ba2ae7565996015322b0bb024e1d25c6fd
+  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 2b3de8a37fcb4eb60f0be0af6b2c18d03410053a
+  cloud_firestore: 45532e0c1fd1f6a5720af8aa0312470c366b73d2
   Firebase: a451a7b61536298fd5cbfe3a746fd40443a50679
-  firebase_analytics: 1c038d9e4edf25828a8985c0be4efcb84cdae32a
-  firebase_auth: c90f1b17fe53a1e9a63222d0b2f33256879b1a92
-  firebase_core: 7ca5e04fc97329a2245376eba53c5bed113ca21e
+  firebase_analytics: 4f9cca09e65f6c2944a862c6dc86f6bed9fb769c
+  firebase_auth: f547a06ed4933a1da2b9ac8d8c64ae09d113c8e1
+  firebase_core: ba00a168e719694f38960502ceb560285603d073
   FirebaseAnalytics: d0a97a0db6425e5a5d966340b87f92ca7b13a557
   FirebaseAppCheckInterop: e2178171b4145013c7c1a3cc464d1d446d3a1896
   FirebaseAuth: 613c463cb43545a7fd2cd99ade09b78ac472c544
@@ -1586,7 +1586,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 631b38da2e11a83daa4bfb482f79d286a5dfa7ad
   FirebaseSharedSwift: 79f27fff0addd15c3de19b87fba426f3cc2c964f
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  google_sign_in_ios: 055d43c4754f2860a53decd5133b78d05615fffd
+  google_sign_in_ios: 00dfa94252eb10278b64828c81bcb7158a81a53a
   GoogleAdsOnDeviceConversion: d68c69dd9581a0f5da02617b6f377e5be483970f
   GoogleAppMeasurement: 3bf40aff49a601af5da1c3345702fcb4991d35ee
   GoogleSignIn: c7f09cfbc85a1abf69187be091997c317cc33b77
@@ -1595,16 +1595,16 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
+  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  video_player_avfoundation: 7993f492ae0bd77edaea24d9dc051d8bb2cd7c86
-  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
+  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 
 PODFILE CHECKSUM: 1857a7cdb7dfafe45f2b0e9a9af44644190f7506
 

--- a/lib/data/repositories/video_cache_repository.dart
+++ b/lib/data/repositories/video_cache_repository.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../services/google_drive_service.dart';
-import '../services/video_cache_service_web.dart';
+import '../services/video_cache_service.dart';
 
 /// 動画キャッシュリポジトリ
 /// プラットフォーム分岐（Web/モバイル）とキャッシュ戦略を管理

--- a/lib/data/services/video_cache_service.dart
+++ b/lib/data/services/video_cache_service.dart
@@ -1,0 +1,7 @@
+// 動画キャッシュサービス
+// プラットフォームに応じて適切な実装を提供
+//
+// Web: IndexedDBを使用したキャッシュ実装
+// その他: スタブ実装（何もしない）
+export 'video_cache_service_stub.dart'
+    if (dart.library.js_interop) 'video_cache_service_web.dart';

--- a/lib/data/services/video_cache_service_stub.dart
+++ b/lib/data/services/video_cache_service_stub.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+
+/// 動画キャッシュサービスのスタブ実装
+/// サポートされていないプラットフォーム用
+class VideoCacheServiceWeb {
+  Future<void> init() {
+    throw UnsupportedError(
+      'Video cache service is not supported on this platform',
+    );
+  }
+
+  Future<bool> isCached(String videoFileId) {
+    return Future.value(false);
+  }
+
+  Future<String?> getCachedVideoUrl(String videoFileId) {
+    return Future.value();
+  }
+
+  Future<void> cacheVideo(String videoFileId, Uint8List data) {
+    throw UnsupportedError(
+      'Video cache service is not supported on this platform',
+    );
+  }
+
+  Future<void> clearOldCache() {
+    return Future.value();
+  }
+
+  Future<void> clearAllCache() {
+    return Future.value();
+  }
+
+  Future<void> dispose() {
+    return Future.value();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ import 'data/repositories/playback_repository.dart';
 import 'data/repositories/video_cache_repository.dart';
 import 'data/repositories/video_repository.dart';
 import 'data/services/google_drive_service.dart';
-import 'data/services/video_cache_service_web.dart';
+import 'data/services/video_cache_service.dart';
 import 'domain/entities/channel.dart';
 import 'domain/entities/video.dart';
 import 'firebase_options.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,13 +68,6 @@ class MyApp extends StatelessWidget {
           create: (_) => AuthRepository(),
         ),
 
-        // Phase 1: AuthProvider
-        ChangeNotifierProvider(
-          create: (context) => AuthProvider(
-            context.read<AuthRepository>(),
-          ),
-        ),
-
         // Phase 2: Repositories - Base Dependencies
         // GoogleDriveService（VideoCacheRepositoryでも使用するため、先に作成）
         Provider<GoogleDriveService>(
@@ -98,6 +91,7 @@ class MyApp extends StatelessWidget {
         ),
 
         // VideoCacheRepository（Web版のみ動画キャッシュ機能を使用）
+        // AuthProviderでも使用するため、AuthProviderより前に作成
         Provider<VideoCacheRepository>(
           create: (context) {
             final driveService = context.read<GoogleDriveService>();
@@ -106,6 +100,14 @@ class MyApp extends StatelessWidget {
               videoCacheServiceWeb: kIsWeb ? VideoCacheServiceWeb() : null,
             );
           },
+        ),
+
+        // Phase 1: AuthProvider
+        ChangeNotifierProvider(
+          create: (context) => AuthProvider(
+            context.read<AuthRepository>(),
+            context.read<VideoCacheRepository>(),
+          ),
         ),
 
         // Phase 3: Analytics

--- a/lib/presentation/screens/video/video_player_screen.dart
+++ b/lib/presentation/screens/video/video_player_screen.dart
@@ -17,7 +17,8 @@ import '../../../domain/entities/video.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/playback_provider.dart';
 import '../../widgets/video/playback_speed_selector.dart';
-import '../../widgets/video/web_video_player.dart';
+import '../../widgets/video/web_video_player_stub.dart'
+    if (dart.library.js_interop) '../../widgets/video/web_video_player.dart';
 
 /// 動画再生画面
 /// Google Driveから動画をストリーミング再生

--- a/lib/presentation/widgets/video/web_video_player.dart
+++ b/lib/presentation/widgets/video/web_video_player.dart
@@ -48,6 +48,8 @@ class WebVideoPlayerController {
     this.autoPlay = false,
   }) {
     _viewType = 'video-player-${_nextViewId++}';
+    // コンストラクタでvideoエレメントを登録
+    _registerVideoElement();
   }
 
   final String videoUrl;
@@ -79,7 +81,8 @@ class WebVideoPlayerController {
   double get playbackSpeed => _playbackSpeed;
 
   void _attach() {
-    _registerVideoElement();
+    // VideoElementは既にコンストラクタで登録済み
+    // ここでは何もしない
   }
 
   void _detach() {
@@ -88,6 +91,8 @@ class WebVideoPlayerController {
   }
 
   void _registerVideoElement() {
+    debugPrint('[WebVideoPlayerController] VideoElement登録開始: $videoUrl');
+
     // VideoElementを作成
     _videoElement = web.document.createElement('video') as web.HTMLVideoElement
       ..src = videoUrl
@@ -100,6 +105,7 @@ class WebVideoPlayerController {
     _videoElement!.addEventListener(
       'loadedmetadata',
       (web.Event _) {
+        debugPrint('[WebVideoPlayerController] loadedmetadataイベント受信');
         _duration = Duration(
           milliseconds: (_videoElement!.duration * 1000).toInt(),
         );
@@ -163,13 +169,18 @@ class WebVideoPlayerController {
   }
 
   Future<void> initialize() async {
+    debugPrint('[WebVideoPlayerController] initialize開始');
+
     // HTML VideoElementの場合、loadedmetadataイベントで初期化完了
     if (_isInitialized) {
+      debugPrint('[WebVideoPlayerController] 既に初期化済み');
       return;
     }
 
+    debugPrint('[WebVideoPlayerController] loadedmetadataイベントを待機中...');
     // 初期化完了を待つ
     await onInitialized.first;
+    debugPrint('[WebVideoPlayerController] initialize完了');
   }
 
   Future<void> play() async {

--- a/lib/presentation/widgets/video/web_video_player_stub.dart
+++ b/lib/presentation/widgets/video/web_video_player_stub.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Web版動画プレイヤー（スタブ実装）
+/// モバイル/デスクトップ環境では使用されない
+class WebVideoPlayer extends StatelessWidget {
+  const WebVideoPlayer({
+    required this.controller,
+    super.key,
+  });
+
+  final WebVideoPlayerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    throw UnsupportedError('WebVideoPlayer is not supported on this platform');
+  }
+}
+
+/// Web版動画プレイヤーコントローラー（スタブ実装）
+/// モバイル/デスクトップ環境では使用されない
+class WebVideoPlayerController {
+  WebVideoPlayerController({
+    required this.videoUrl,
+    this.autoPlay = false,
+  });
+
+  final String videoUrl;
+  final bool autoPlay;
+
+  bool get isInitialized => false;
+  bool get isPlaying => false;
+  Duration get position => Duration.zero;
+  Duration get duration => Duration.zero;
+  double get playbackSpeed => 1;
+
+  Stream<void> get onInitialized => const Stream.empty();
+  Stream<Duration> get onPositionChanged => const Stream.empty();
+
+  Future<void> initialize() async {}
+  Future<void> play() async {}
+  Future<void> pause() async {}
+  Future<void> seekTo(Duration position) async {}
+  Future<void> setPlaybackSpeed(double speed) async {}
+  void dispose() {}
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   just_audio: ^0.9.0
   provider: ^6.1.5+1
   video_player: ^2.9.2
-  web: ^1.1.0
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Web版とモバイル版のプラットフォーム分岐を整理し、ログアウト時のデータクリーンアップ機能を追加しました。

- 動画キャッシュサービスのプラットフォーム分岐をconditional importで実装
- ログアウト時にWeb版IndexedDBの動画キャッシュを自動削除
- Web版動画プレイヤーのプラットフォーム分岐を改善
- 初期化タイミングとデバッグログを最適化

## 変更内容

### 1. 動画キャッシュサービスのプラットフォーム分岐整理
- `video_cache_service.dart`をconditional importで分岐
- モバイル用スタブ実装（`video_cache_service_stub.dart`）を追加
- Web版のみIndexedDBを使用する構造に

### 2. ログアウト時のIndexedDBクリーンアップ
- `AuthProvider`に`VideoCacheRepository`依存を追加
- `signOut()`でWeb版のみIndexedDBの動画キャッシュをクリア
- キャッシュクリア失敗時もログアウト処理は続行するエラーハンドリング
- プロバイダー作成順序を調整（`VideoCacheRepository` → `AuthProvider`）

### 3. Web版動画プレイヤーの改善
- conditional importでWeb/モバイル版を分岐
- モバイル用スタブ実装（`web_video_player_stub.dart`）を追加
- VideoElement登録をコンストラクタに移動して初期化タイミングを修正
- デバッグログを追加して処理フローを可視化

### 4. 依存関係の更新
- webパッケージを1.1.1に更新

## Test plan

- [ ] Web版: ログイン → 動画視聴（キャッシュ） → ログアウト → IndexedDBが空になることを確認
- [ ] Web版: 動画再生が正常に動作することを確認
- [ ] モバイル版: ビルドが通ることを確認
- [ ] モバイル版: 動画再生が正常に動作することを確認
- [ ] Lint: `dart analyze --fatal-infos` が0エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)